### PR TITLE
Allow hierarchical app names, like: 'foo.bar'

### DIFF
--- a/tests/unit/test_nose_runner.py
+++ b/tests/unit/test_nose_runner.py
@@ -32,7 +32,8 @@ import nose
 from StringIO import StringIO
 from django.conf import settings
 from django.core import management
-from sure import that, that_with_context
+from sure.deprecated import that
+from sure import that_with_context
 
 from unclebob.runners import Nose
 

--- a/unclebob/runners.py
+++ b/unclebob/runners.py
@@ -100,7 +100,7 @@ class Nose(DjangoTestSuiteRunner):
 
         def for_packages(package):
             try:
-                imp.find_module(package)
+                self.import_app_module(package)
                 return True
             except ImportError:
                 return False
@@ -125,8 +125,7 @@ class Nose(DjangoTestSuiteRunner):
 
         for name in appnames:
             try:
-                params = imp.find_module(name)
-                module = imp.load_module(name, *params)
+                module = self.import_app_module(name)
                 module_filename = module.__file__
                 module_path = dirname(module_filename)
             except ImportError:
@@ -144,6 +143,20 @@ class Nose(DjangoTestSuiteRunner):
                 paths.append(path)
 
         return unique(paths)
+
+    def import_app_module(self, name):
+        """
+        Given a module name like 'foo' or 'foo.bar' imports and returns the
+        module object
+        """
+        bits = name.split('.')
+        path = None
+        while bits:
+            bit = bits.pop(0)
+            params = imp.find_module(bit, path)
+            module = imp.load_module(bit, *params)
+            path = module.__path__
+        return module
 
     def migrate_to_south_if_needed(self):
         should_migrate = getattr(settings, 'SOUTH_TESTS_MIGRATE', False)


### PR DESCRIPTION
`./manage.py test` was aways running all tests for me because this project has app names like 'foo.bar'. Turns out `imp.find_module()` does not handle hierarchical modules.

I've created a new method `import_app_module` on nose runner class to handle it.
It could be a function in a separate helper module, my idea is to refactor it later when adding support for other runners, I'd like to add a py.test runner class :)

BTW, nice module Gabriel, always helping to improve testing in python :)
